### PR TITLE
解决puppet库提示selfId()已被废弃, 使用 `currentUserId`替代问题

### DIFF
--- a/packages/puppet/src/schema-mapper/message.ts
+++ b/packages/puppet/src/schema-mapper/message.ts
@@ -13,7 +13,7 @@ function rewriteMsgContent(message: string) {
 
 export async function wechatferryMessageToWechaty(puppet: PUPPET.Puppet, message: WechatferryAgentEventMessage): Promise<PuppetMessage> {
   let text = message.content
-  const selfId = puppet.selfId()
+  const selfId = puppet.currentUserId
   const roomId = message.is_group ? message.roomid : ''
   const fromId = message.sender
   const toId = message.is_self ? message.roomid : selfId


### PR DESCRIPTION
### 错误
 WARN PuppetLoginMixin selfId() is deprecated, use `currentUserId` instead:
Error
    at Proxy.selfId (E:\1.rebot\node_modules\wechaty-puppet\src\mixins\login-mixin.ts:148:9)
    at wechatferryMessageToWechaty (E:\1.rebot\node_modules\@wechatferry\puppet\dist\index.cjs:745:25)
    at Proxy.messageRawPayloadParser (E:\1.rebot\node_modules\@wechatferry\puppet\dist\index.cjs:1506:12)
    at Proxy.messagePayload (E:\1.rebot\node_modules\wechaty-puppet\src\mixins\message-mixin.ts:137:37)
    at async Proxy.messageSearch (E:\1.rebot\node_modules\wechaty-puppet\src\mixins\message-mixin.ts:161:11)
    at async Function.findAll (E:\1.rebot\node_modules\wechaty\src\user-modules\message.ts:135:29)
    at async Function.find (E:\1.rebot\node_modules\wechaty\src\user-modules\message.ts:110:25)
    at async Proxy.<anonymous> (E:\1.rebot\node_modules\wechaty\src\wechaty-mixins\puppet-mixin.ts:275:29)
14:35:27 WARN PuppetLoginMixin selfId() is deprecated, use `currentUserId` instead: